### PR TITLE
Add Example Files and Deb Package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,17 @@ time = "=0.2.22" # TODO
 tokio = { version = "1.18.4", features = ["rt-multi-thread", "macros", "io-std", "fs"] }
 tokio-rustls = "0.22.0"
 tokio-util = { version = "0.7.2", default-features = false, features = ["codec"] }
+
+[package.metadata.deb]
+extended-description = """\
+Simple and fast web server as a single executable with no extra dependencies required."""
+maintainer-scripts = "systemd/"
+systemd-units = { enable = false }
+depends = "$auto"
+section = "utility"
+priority = "optional"
+conf-files = ["/etc/see/server.conf"]
+assets = [
+    ["target/release/see", "usr/bin/see-server", "755"],
+    ["see-default.conf", "/etc/see/server.conf", "644"],
+]

--- a/see-default.conf
+++ b/see-default.conf
@@ -1,0 +1,5 @@
+server {
+    listen 80
+    root /var/www/html/
+}
+

--- a/systemd/see.service
+++ b/systemd/see.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Simple satic resource web server 
+
+[Service]
+ExecStart=/usr/bin/see-server -c /etc/see/server.conf
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Hi,

For my specific need I created a deb package with cargo deb of see, this PR add in the cargo toml the configuration for create the deb package, and add default configuration and a systemd unit file to run it as service.

with this run `cargo deb` on the project would produce a package with the following content:
```
drwxr-xr-x 0/0               0  usr/
drwxr-xr-x 0/0               0  usr/share/
drwxr-xr-x 0/0               0  usr/share/doc/
drwxr-xr-x 0/0               0  usr/share/doc/see/
-rw-r--r-- 0/0             186  usr/share/doc/see/copyright
drwxr-xr-x 0/0               0  etc/
drwxr-xr-x 0/0               0  etc/see/
-rw-r--r-- 0/0              50  etc/see/server.conf
drwxr-xr-x 0/0               0  lib/
drwxr-xr-x 0/0               0  lib/systemd/
drwxr-xr-x 0/0               0  lib/systemd/system/
-rw-r--r-- 0/0             156  lib/systemd/system/see.service
drwxr-xr-x 0/0               0  usr/bin/
-rwxr-xr-x 0/0         6097608  usr/bin/see-server

```
here the binary is renamd to `see-server` to avoid potential conflict with other debian binaries.

Let me know if you are interested in integrating cargo deb, or even if you like to merge only part of this PR like the systemd unit file.

Regards.